### PR TITLE
Fix script not working anymore

### DIFF
--- a/instagram-video-controls.user.js
+++ b/instagram-video-controls.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Instagram Video Controls
 // @namespace    instagram_video
-// @version      0.2.1
+// @version      0.2.2
 // @description  Adds standart video controls for video in Instagram
 // @homepageURL  https://github.com/0xC0FFEEC0DE/instagram-video-controls
 // @supportURL   https://github.com/0xC0FFEEC0DE/instagram-video-controls/issues
@@ -15,27 +15,49 @@
 
 (function() {
     'use strict';
-
+    
     let videoObserver = new MutationObserver(function(mutations) {
         mutations.forEach(function(mutation) {
-            let video = mutation.target;
-            //console.log(video);
-            if(!video.controls) {
-                video.controls = 'controls';
-                let article = video.closest('article');
-                article.querySelectorAll('.QvAa1, .oujXn').forEach(trash => {
-                    trash.parentNode.removeChild(trash);
+            
+            // Check for the play button to be removed, i.e. the video is being played
+            if (mutation.removedNodes) {
+                mutation.removedNodes.forEach(removedNode => {
+                    if (removedNode.classList.contains('_8jZFn')) {
+                        
+                        // The <video/> element should be before the removed button
+                        var video = mutation.previousSibling;                      
+                        if (video && video.tagName && video.tagName.toLowerCase() == 'video') {
+                            
+                            if (!video.controls) {
+                                
+                                // Add native video controls
+                                video.controls = 'controls';
+                                
+                                // Remove overlay
+                                let article = video.closest('article');
+                                article.querySelectorAll('.QvAa1, .oujXn').forEach(trash => {
+                                    trash.parentNode.removeChild(trash);
+                                });
+                                
+                                // Keep volume value in localStorage
+                                video.volume = localStorage.getItem('video_volume') || 1;
+                                video.onvolumechange = (event) => {
+                                    localStorage.setItem('video_volume', event.target.volume);
+                                };
+                                
+                            }
+                            
+                        }
+                        
+                    }
                 });
-
-                video.volume = localStorage.getItem('video_volume') || 1;
-                video.onvolumechange = (event) => {
-                    localStorage.setItem('video_volume', event.target.volume);
-                };
             }
+            
         });
     }).observe(document.body, {
-        attributes: true,
+        childList: true,
         subtree: true,
-        attributeFilter: ['loop']
+        attributes: false,
+        characterData: false
     });
 })();


### PR DESCRIPTION
Apparently Instagram changed something, making the script stop working.

The `loop` attribute isn't set on the `<video>` element when playing, so we can't rely on it to detect video playback anymore. I changed the observer to detect for the play button element to disappear, instead.

Plus, I added some comments while trying to figure out how the script worked :slightly_smiling_face: